### PR TITLE
refactor(ubi-card): change UBI Accrued to UBI

### DIFF
--- a/_pages/profile/[id]/submission-details-card/ubi-card.js
+++ b/_pages/profile/[id]/submission-details-card/ubi-card.js
@@ -18,9 +18,7 @@ function AccruedUBI({ lastMintedSecond, web3, accruedPerSecond }) {
         .sub(lastMintedSecond)
         .mul(accruedPerSecond);
 
-  return (
-    <Text>{accruedUBI && `${web3.utils.fromWei(accruedUBI)} UBI Accrued`}</Text>
-  );
+  return <Text>{accruedUBI && `${web3.utils.fromWei(accruedUBI)} UBI`}</Text>;
 }
 export default function UBICard({ submissionID }) {
   const { web3 } = useWeb3();


### PR DESCRIPTION
functionally, it displays real time wallet balance, so instead of saying ubi accrued, we should only just ubi, to be consistent