### PR TITLE
fix: let popup modal scroll when content is long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-beta.4 (2021-04-05)
+## 1.0.0-beta.4 (2021-04-07)
 
 - chore: add button on click documentation ([fb493c5](https://github.com/Proof-Of-Humanity/proof-of-humanity-web/commit/fb493c5))
 - chore: add code of conduct ([6859555](https://github.com/Proof-Of-Humanity/proof-of-humanity-web/commit/6859555))
@@ -86,6 +86,7 @@
 - chore: fix typo ([80e4c50](https://github.com/Proof-Of-Humanity/proof-of-humanity-web/commit/80e4c50))
 - chore: fix unsupported network switch ([d2b384a](https://github.com/Proof-Of-Humanity/proof-of-humanity-web/commit/d2b384a))
 - chore: fix weird Web3 inconsistency ([5d205ad](https://github.com/Proof-Of-Humanity/proof-of-humanity-web/commit/5d205ad))
+- chore: fixed CI config for AssemblyScript TS files ([1703c74](https://github.com/Proof-Of-Humanity/proof-of-humanity-web/commit/1703c74))
 - chore: fixes ([d55fd84](https://github.com/Proof-Of-Humanity/proof-of-humanity-web/commit/d55fd84))
 - chore: fixes ([cb1aaa6](https://github.com/Proof-Of-Humanity/proof-of-humanity-web/commit/cb1aaa6))
 - chore: fixes ([e6cad14](https://github.com/Proof-Of-Humanity/proof-of-humanity-web/commit/e6cad14))

--- a/components/popup.js
+++ b/components/popup.js
@@ -5,6 +5,7 @@ import { Box } from "theme-ui";
 const AnimatedBox = animated(Box);
 export default function Popup({
   contentStyle,
+  overlayStyle,
   onOpen,
   onClose,
   sx,
@@ -24,6 +25,7 @@ export default function Popup({
         boxShadow: "none",
         ...contentStyle,
       }}
+      overlayStyle={{ overflow: "scroll", ...overlayStyle }}
       onOpen={() => {
         setAnimatedStyle({ opacity: 1, scale: 1 });
         if (onOpen) onOpen();


### PR DESCRIPTION
# Description
`<Popup modal>` won't allow scroll content on small screens

![image](https://user-images.githubusercontent.com/1024246/113911983-a0064f00-97a8-11eb-935e-beebc57683d4.png)

Fix is to allow scroll on overlay, example:

https://user-images.githubusercontent.com/1024246/113912210-da6fec00-97a8-11eb-9202-ff9fa11d8160.mp4



# Rationale

Allow people to use a browser mobile wallet to interact with the dapp.

# How To Test This?

Run storybook and change "Content" to a long content in popup stories.
