### PR TITLE
fix: remove default network from query params

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -295,7 +295,7 @@ export default function App({ Component, pageProps }) {
 
   const onNetworkChange = useCallback(
     ({ name: _network }) => {
-      if (router.query.network !== _network) {
+      if (networkFromQuery !== _network) {
         const searchParameters = new URLSearchParams(location.search);
         if (!_network) searchParameters.delete("network");
         else searchParameters.set("network", _network);
@@ -306,7 +306,7 @@ export default function App({ Component, pageProps }) {
         });
       }
     },
-    [router]
+    [router, networkFromQuery]
   );
 
   const transitions = useTransition(


### PR DESCRIPTION
Resolves #133 

Removes adding `?network=mainnet` query to the URL by default. If user explicitly visits `?network=kovan` but web3 is connected to `mainnet`, the URL will be changed to `?network=mainnet` to reflect the change. Let me know if you think, we should just remove the query in this case as well