### PR TITLE
fix: block multiple request submissions #308

### DIFF
--- a/_pages/profile/[id]/submit-profile-form.js
+++ b/_pages/profile/[id]/submit-profile-form.js
@@ -434,6 +434,8 @@ const SubmitProfileForm = memo(
             </Card>
             <Button
               type="submit"
+              disabled={isSubmitting}
+              loading={isSubmitting}
               sx={{
                 width: "120px",
               }}


### PR DESCRIPTION
A simple fix for #308

Adds disabled state to submit button using Formik's `isSubmitting`

This isn't the most elegant solution, but quickly addresses the issue with minimal regression risk. We still don't handle the users experience once the transaction is confirmed (and web3 returns the hash). Ideally this would be a dialog or landing page. I will put in a separate issue for this.