### PR TITLE
Fix: incorrect ruling value

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -328,6 +328,10 @@ type Challenge @entity {
   """
   disputeID: BigInt
   """
+  The address of the requesterd.
+  """
+  requester: Bytes
+  """
   The address of the challenger.
   """
   challenger: Bytes
@@ -405,6 +409,18 @@ type Contribution @entity {
   The contributions for each side.
   """
   values: [BigInt!]!
+  """
+  The request receiving the contribution.
+  """
+  requestIndex: BigInt!
+  """
+  The round receiving the contribution.
+  """
+  roundIndex: BigInt!
+  """
+  Whether the request is resolved
+  """
+  requestResolved: Boolean!
 }
 
 type _Schema_

--- a/subgraph/src/mapping.ts
+++ b/subgraph/src/mapping.ts
@@ -1018,11 +1018,11 @@ export function rule(call: RuleCall): void {
       )
       .toHexString()
   );
-  challenge.ruling = proofOfHumanity.getChallengeInfo(
+  challenge.ruling = BigInt.fromI32(proofOfHumanity.getChallengeInfo(
     disputeData.value1,
     requestIndex,
     disputeData.value0
-  ).value2;
+  ).value3);
   challenge.save();
 }
 


### PR DESCRIPTION
Previous code was saving the disputeID in the `ruling` field of the challenge.
Also added additional fields to allow more flexible and efficient queries.