### PR TITLE
Frozen letter in search bar

### DIFF
--- a/_pages/index/submission-filters.js
+++ b/_pages/index/submission-filters.js
@@ -39,6 +39,7 @@ export default function SubmissionFilters({
           if (!event.target.value) delete query.search;
           else query.search = event.target.value.replaceAll(" ", " & ");
           router.push({
+            pathname: "/",
             query,
           });
         }}


### PR DESCRIPTION
## Couldn't erase search bar input after searching
1. Search for "Tom"
2. Try to delete search input
3. "T" can't be erased

This was fixed by adding the _pathname: '/'_ key/value to the object passed to _router.push_.