### PR TITLE
ALL option not working in SELECT INPUT

### DIFF
--- a/_pages/index/submission-filters.js
+++ b/_pages/index/submission-filters.js
@@ -68,6 +68,7 @@ export default function SubmissionFilters({
           }
           delete query.skip;
           router.push({
+            pathname: "/",
             query,
           });
         }}


### PR DESCRIPTION
## Couldn't reset filtering
1. Filter by "Registered" 
2. Filter by "ALL"
3. Cards are still filtered by "Registered"

This was fixed by including the _pathname: '/'_ key/value to the object that _router.push_ receives.