### PR TITLE
Using spaces doesn't work in search bar

### DIFF
--- a/_pages/index/submission-filters.js
+++ b/_pages/index/submission-filters.js
@@ -33,11 +33,11 @@ export default function SubmissionFilters({
         aria-label="Search (case sensitive)"
         placeholder="Search (case sensitive)"
         icon={<Search />}
-        value={router.query.search?.replaceAll(" & ", " ") || ""}
+        value={router.query.search || ""}
         onChange={(event) => {
           const query = { ...router.query };
           if (!event.target.value) delete query.search;
-          else query.search = event.target.value.replaceAll(" ", " & ");
+          else query.search = event.target.value;
           router.push({
             query,
           });


### PR DESCRIPTION
## Couldn't search for full name
1. Search for "Federico"
2. The profile "Federico Ast" appears
3. Search for "Federico Ast"
4. No profiles appear

This was fixed by removing a line that replaced spaces with &.