### PR TITLE
When spacing, search input is filled by &

### DIFF
--- a/_pages/index/submission-filters.js
+++ b/_pages/index/submission-filters.js
@@ -37,7 +37,7 @@ export default function SubmissionFilters({
         onChange={(event) => {
           const query = { ...router.query };
           if (!event.target.value) delete query.search;
-          else query.search = event.target.value.replaceAll(" ", " & ");
+          else query.search = event.target.value;
           router.push({
             pathname: "/",
             query,


### PR DESCRIPTION
## Can't use spacebar properly in search input
1. Go to search bar
2. Space a few times
3. Input is filled by "&"

This bug comes from a line that was kept in a prior merge, .replaceAll() was removed to fix it.