### PR TITLE
Fix: Can't challenge using duplicate as a reason

### DIFF
--- a/_pages/profile/[id]/submission-details-card/deadlines/challenge-button.js
+++ b/_pages/profile/[id]/submission-details-card/deadlines/challenge-button.js
@@ -226,7 +226,11 @@ export default function ChallengeButton({ request, status, submissionID }) {
           />
           <Button
             sx={{ display: "block", margin: "auto" }}
-            disabled={(duplicateTypeSelected && !duplicate) || !arbitrationCost}
+            disabled={
+              (duplicateTypeSelected && !duplicate) ||
+              !arbitrationCost ||
+              !reason
+            }
             onClick={async () => {
               let evidenceUploadResult;
               if (reason && reason.length > 0)


### PR DESCRIPTION
The error arose when trying to submit a challenge with no justification. We have decided to make the justification mandatory in the UI, so the button will be disabled unless there is something written on the field. 