### PR TITLE
fix: batchSend now sends correct challengeID

### DIFF
--- a/_pages/index/app-query.js
+++ b/_pages/index/app-query.js
@@ -29,6 +29,7 @@ export const appQuery = graphql`
       round {
         challenge {
           id
+          challengeID
           request {
             submission {
               id

--- a/components/account-settings-popup.js
+++ b/components/account-settings-popup.js
@@ -55,7 +55,7 @@ export default function AccountSettingsPopup({
       (withdrawableContribution) => {
         const { requestIndex, roundIndex, round } = withdrawableContribution;
         const { challenge } = round;
-        const { request, id: challengeID } = challenge;
+        const { request, challengeID } = challenge;
         const { submission } = request;
         const { id } = submission;
         return pohInstance.methods


### PR DESCRIPTION
An id (presumably) used to uniquely identify Challenge in thegraph `challenge.id` was confused with the contract's way to identify challenges, `challenge.challengeID` , the latter is what had to be fed into batchSend.
I messed up the [first PR](https://github.com/Proof-Of-Humanity/proof-of-humanity-web/pull/423), sorry.