### PR TITLE
fix: upload file to remove request modal

### DIFF
--- a/_pages/profile/[id]/submission-details-card/deadlines/remove-button.js
+++ b/_pages/profile/[id]/submission-details-card/deadlines/remove-button.js
@@ -127,7 +127,7 @@ export default function RemoveButton({ request, contract, submissionID }) {
                 name="file"
                 label="File"
                 accept="image/png, image/jpeg, application/pdf"
-                maxSize={2}
+                maxSize={2 * 1024 * 1024}
               />
               <Button
                 sx={{ display: "block", margin: "auto" }}


### PR DESCRIPTION
It was only taking 2 bytes files at maximum.
Now it takes up to 2 MB.