### PR TITLE
refactor(submission-details-card): fixes #451

### DIFF
--- a/_pages/profile/[id]/submission-details-card/deadlines/index.js
+++ b/_pages/profile/[id]/submission-details-card/deadlines/index.js
@@ -118,7 +118,7 @@ export default function Deadlines({ submission, contract, status }) {
                   contract={contract}
                   submissionID={id}
                 />
-              ) : (
+              ) : Date.now() > renewalTimestamp ? (
                 <NextLink
                   href="/profile/[id]?reapply=true"
                   as={`/profile/${accounts?.[0]}`}
@@ -132,7 +132,7 @@ export default function Deadlines({ submission, contract, status }) {
                     Reapply
                   </Button>
                 </NextLink>
-              )
+              ) : null
             }
           />
           <Deadline


### PR DESCRIPTION
- Introduce a new boolean flag `displayEvenIfDeadlinePasses`. Make it false for the renewal deadline.
- Introduce a new deadline, called expiration. Display renewal button under it, when it's possible to renew, and display remove button when expiration deadline passes. 

![Screenshot from 2021-10-22 15-58-45](https://user-images.githubusercontent.com/3106907/138457579-196f486d-cdc0-4177-8291-2494e780ea72.png)
