### PR TITLE
Fix/vouches query

### DIFF
--- a/_pages/profile/[id]/submission-details-card/index.js
+++ b/_pages/profile/[id]/submission-details-card/index.js
@@ -209,10 +209,7 @@ export default function SubmissionDetailsCard({
         )
       ).json();
       if (res && res.vouches && res.vouches.length > 0)
-        setOffChainVouches(
-          res.vouches.filter(({ resolved }) => resolved === false).vouchers ||
-            []
-        );
+        setOffChainVouches(res.vouches);
     })();
   }, [id]);
 

--- a/_pages/profile/[id]/submission-details-card/ubi-card.js
+++ b/_pages/profile/[id]/submission-details-card/ubi-card.js
@@ -127,16 +127,14 @@ async function getVouchCallsElegibleUsers(
       })),
     ]);
 
-    const validVouches = voucherDatas.flatMap((voucherData, i) => {
-      if (
-        !voucherData.submissionInfo.hasVouched &&
-        voucherData.submissionInfo.registered &&
-        (user.signatures || voucherData.isVouchActive) &&
-        (!user.signatures || user.expirationTimestamps[i] > Date.now() / 1000)
-      )
-        return [i];
-      return [];
-    });
+    const validVouches = voucherDatas.flatMap((voucherData, i) =>
+      !voucherData.submissionInfo.hasVouched &&
+      voucherData.submissionInfo.registered &&
+      (user.signatures || voucherData.isVouchActive) &&
+      (!user.signatures || user.expirationTimestamps[i] > Date.now() / 1000)
+        ? [i]
+        : []
+    );
 
     if (
       validVouches.length < requiredNumberOfVouches ||
@@ -376,6 +374,7 @@ export default function UBICard({
             .call();
 
         if (!voucherRegistered) continue;
+        if (vouches.expirationTimestamps[i] < Date.now() / 1000) continue;
 
         if (!hasVouched) {
           validVouches.signatures.push(vouches.signatures[i]);


### PR DESCRIPTION
Should fix:

- Don't show "Advance to Pending" option if vouches are expired/not valid (example: `0x8b84eb2d86eb83a462faa30e65d12e1c94fbb047 `).
- Don't count used gasless vouches as on-chain vouches when someone reapplies.
- When someone finalizes its registration, only try to advance to pending profiles with valid vouches.