### PR TITLE
fix: vouchReleaseReady per request instead of per submission

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -187,10 +187,6 @@ type Submission @entity {
   """
   requestsLength: BigInt!
   """
-  True if vouch was not processed and vouchee is resolved.
-  """
-  vouchReleaseReady: Boolean!
-  """
   True if this submission was part of the seeding event.
   """
   seeded: Boolean!
@@ -217,6 +213,10 @@ type Request @entity {
   The request's ID, keccak256(submissionID, submissionRequestsLength).
   """
   id: ID!
+  """
+  The request index.
+  """
+  requestIndex: BigInt!
   """
   True if a dispute was raised. Note that the request can enter disputed state multiple times, once per reason.
   """
@@ -301,6 +301,10 @@ type Request @entity {
   The time the request was resolved.
   """
   resolutionTime: BigInt!
+  """
+  True if vouch was not processed and vouchee is resolved.
+  """
+  vouchReleaseReady: Boolean!
 }
 
 type Evidence @entity {


### PR DESCRIPTION
Solves #462.

In this case, the user re-submitted his profile immediately after being rejected and the bot couldn't be aware of it https://github.com/kleros/action-callback-bots/blob/master/src/bots/proof-of-humanity/process-vouches.js.