### PR TITLE
fix(subgraph): disputed to false reapplySubmission

### DIFF
--- a/subgraph/src/mapping.ts
+++ b/subgraph/src/mapping.ts
@@ -657,6 +657,7 @@ export function reapplySubmission(call: ReapplySubmissionCall): void {
   let submission = Submission.load(call.from.toHexString());
   managePreviousStatus(submission, call);
   submission.status = "Vouching";
+  submission.disputed = false;
   submission.save();
   manageCurrentStatus(submission);
 


### PR DESCRIPTION
This may not be correct.
What happens if someone reapplies while there's an ongoing
dispute? Would that cause a bug in the future?