### PR TITLE
feat(evidence): added advice on evidence component

### DIFF
--- a/_pages/profile/[id]/submission-details-accordion.js
+++ b/_pages/profile/[id]/submission-details-accordion.js
@@ -101,6 +101,7 @@ export default function SubmissionDetailsAccordion({ submission, contract }) {
             args={[id]}
             evidences={evidences}
             useEvidenceFile={useEvidenceFile}
+            submission={submission}
           />
         }
       />

--- a/components/evidence.js
+++ b/components/evidence.js
@@ -1,6 +1,7 @@
 import { DownArrow, File, UpArrow } from "@kleros/icons";
 import { Box, Flex } from "theme-ui";
 
+import Alert from "./alert";
 import Card from "./card";
 import Identicon from "./identicon";
 import Link from "./link";
@@ -74,6 +75,7 @@ export default function Evidence({
   args,
   evidences,
   useEvidenceFile,
+  submission,
 }) {
   return (
     <ScrollTo>
@@ -100,6 +102,15 @@ export default function Evidence({
               />
             </Text>
           </Flex>
+          {submission?.disputed && (
+            <Alert type="muted" title="Advice" sx={{ mb: 3 }}>
+              <Text>
+                Only send evidence if you believe that the submission is correct
+                as it is. Sending new files as evidence won&apos;t help if the
+                submitted ones are incorrect.
+              </Text>
+            </Alert>
+          )}
           <ScrollArea
             sx={{
               marginBottom: 2,


### PR DESCRIPTION
I added an Alert on the Evidence component to let disputed people know that sending evidence might not help with the dispute if their submission is, indeed, incorrect. 
Should be simple to merge into the master of the repo. 