### PR TITLE
feat(registration): added an optional contact information field to th…

### DIFF
--- a/_pages/profile/[id]/submission-details-card/index.js
+++ b/_pages/profile/[id]/submission-details-card/index.js
@@ -177,6 +177,7 @@ export default function SubmissionDetailsCard({
       .join(" ") || name;
   const displayName =
     compoundName === name ? name : `${compoundName} (${name})`;
+    const contactInfo = evidence?.file?.contact;
 
   const [arbitrationCost] = useContract(
     "klerosLiquid",
@@ -279,6 +280,7 @@ export default function SubmissionDetailsCard({
           variant="avatar"
           src={evidence?.file?.photo}
         />
+        
         <Text
           sx={{
             fontSize: 2,
@@ -295,6 +297,10 @@ export default function SubmissionDetailsCard({
                 ? evidence.file.name
                 : "We are doing some maintenance work and will be online again soon.")}
         </Text>
+        {contactInfo !== undefined && (
+        <Text as="span" sx={{ fontWeight: "bold" }}>
+          {"Contact info: \n"+contactInfo}
+        </Text>)}
         <Text sx={{ wordBreak: "break-word" }} count={2}>
           {evidence?.file ? evidence.file.bio || " " : null}
         </Text>
@@ -426,6 +432,7 @@ export default function SubmissionDetailsCard({
             fontWeight: "bold",
           }}
         />
+        
         <Video url={evidence?.file?.video} />
         <UBICard
           submissionID={id}

--- a/_pages/profile/[id]/submit-profile-form.js
+++ b/_pages/profile/[id]/submit-profile-form.js
@@ -130,6 +130,8 @@ const SubmitProfileForm = memo(
                   /^[\s\w]*$/,
                   "Only letters from a to z and spaces are allowed."
                 ),
+                contact: string()
+                .max(30,"Must be 30 characters or less."),
               bio: string().max(70, "Must be 70 characters or less."),
               photo: file()
                 .required("Required")
@@ -249,6 +251,7 @@ const SubmitProfileForm = memo(
           name,
           firstName,
           lastName,
+          contact,
           bio,
           photo,
           video,
@@ -265,7 +268,7 @@ const SubmitProfileForm = memo(
           pageScroll();
           const { pathname: fileURI } = await upload(
             "file.json",
-            JSON.stringify({ name, firstName, lastName, bio, photo, video })
+            JSON.stringify({ name, firstName, lastName, contact, bio, photo, video })
           );
           const { pathname: evidence } = await uploadWithProgress(
             "registration.json",
@@ -388,6 +391,11 @@ const SubmitProfileForm = memo(
               name="lastName"
               label="Last Name"
               placeholder="(In basic Latin)"
+            />
+            <Field
+              name="contact"
+              label="Contact Info (optional)"
+              placeholder="You may add any kind of contact information in case anyone wants to reach you"
             />
             <Field as={Textarea} name="bio" label="Short Bio" />
             <Alert type="muted" title="Pro Tip" sx={{ mb: 3 }}>

--- a/_pages/profile/[id]/submit-profile-form.js
+++ b/_pages/profile/[id]/submit-profile-form.js
@@ -130,8 +130,7 @@ const SubmitProfileForm = memo(
                   /^[\s\w]*$/,
                   "Only letters from a to z and spaces are allowed."
                 ),
-                contact: string()
-                .max(30,"Must be 30 characters or less."),
+              contact: string().max(30, "Must be 30 characters or less."),
               bio: string().max(70, "Must be 70 characters or less."),
               photo: file()
                 .required("Required")
@@ -268,7 +267,15 @@ const SubmitProfileForm = memo(
           pageScroll();
           const { pathname: fileURI } = await upload(
             "file.json",
-            JSON.stringify({ name, firstName, lastName, contact, bio, photo, video })
+            JSON.stringify({
+              name,
+              firstName,
+              lastName,
+              contact,
+              bio,
+              photo,
+              video,
+            })
           );
           const { pathname: evidence } = await uploadWithProgress(
             "registration.json",


### PR DESCRIPTION
As it has been made clear in the past few months, Ethmail didn't work as a solution to getting in touch with submitters with incorrect submissions. That is why I added a new field onto the registration process so that people that want to can add some contact information. This field is optional and will only be shown if there is info on the file.json file from IPFS.
For any inquiries on this matter you can reach me here or at Telegram (https://t.me/nicobilinkis).