### PR TITLE
feat(smallAvatar): display on red disputed and removed vouchees

### DIFF
--- a/_pages/profile/[id]/submission-details-card/small-avatar.js
+++ b/_pages/profile/[id]/submission-details-card/small-avatar.js
@@ -9,6 +9,8 @@ export default function SmallAvatar({ submissionId }) {
       query smallAvatarQuery($id: ID!) {
         submission(id: $id) {
           id
+          status
+          disputed
           name
           requests(
             orderBy: creationTime
@@ -38,7 +40,40 @@ export default function SmallAvatar({ submissionId }) {
         evidence.file.name.replaceAll(/[^\s\w]/g, "")
           ? evidence.file.name
           : "We are doing some maintenance work and will be online again soon.");
-  return (
+  return submission?.status === "None" && submission?.disputed ? (
+    <NextLink href="/profile/[id]" as={`/profile/${submissionId}`}>
+      <Link
+        sx={{
+          height: 32,
+          marginRight: 1,
+        }}
+        newTab
+      >
+        <Popup
+          trigger={
+            <Box
+              sx={{
+                span: { display: "flex" },
+              }}
+            >
+              <Image
+                variant="challengedSmallAvatar"
+                src={evidence?.file?.photo}
+              />
+            </Box>
+          }
+          on={["focus", "hover"]}
+          sx={{
+            color: "text",
+            fontSize: 1,
+            textAlign: "center",
+          }}
+        >
+          {name}
+        </Popup>
+      </Link>
+    </NextLink>
+  ) : (
     <NextLink href="/profile/[id]" as={`/profile/${submissionId}`}>
       <Link
         sx={{

--- a/_pages/profile/[id]/submission-details-card/small-avatar.js
+++ b/_pages/profile/[id]/submission-details-card/small-avatar.js
@@ -40,7 +40,11 @@ export default function SmallAvatar({ submissionId }) {
         evidence.file.name.replaceAll(/[^\s\w]/g, "")
           ? evidence.file.name
           : "We are doing some maintenance work and will be online again soon.");
-  return submission?.status === "None" && submission?.disputed ? (
+  const variant =
+    submission?.status === "None" && submission?.disputed
+      ? "challengedSmallAvatar"
+      : "smallAvatar";
+  return (
     <NextLink href="/profile/[id]" as={`/profile/${submissionId}`}>
       <Link
         sx={{
@@ -56,40 +60,7 @@ export default function SmallAvatar({ submissionId }) {
                 span: { display: "flex" },
               }}
             >
-              <Image
-                variant="challengedSmallAvatar"
-                src={evidence?.file?.photo}
-              />
-            </Box>
-          }
-          on={["focus", "hover"]}
-          sx={{
-            color: "text",
-            fontSize: 1,
-            textAlign: "center",
-          }}
-        >
-          {name}
-        </Popup>
-      </Link>
-    </NextLink>
-  ) : (
-    <NextLink href="/profile/[id]" as={`/profile/${submissionId}`}>
-      <Link
-        sx={{
-          height: 32,
-          marginRight: 1
-        }}
-        newTab
-      >
-        <Popup
-          trigger={
-            <Box
-              sx={{
-                span: { display: "flex" },
-              }}
-            >
-              <Image variant="smallAvatar" src={evidence?.file?.photo} />
+              <Image variant={variant} src={evidence?.file?.photo} />
             </Box>
           }
           on={["focus", "hover"]}

--- a/_pages/profile/[id]/submission-details-card/small-avatar.js
+++ b/_pages/profile/[id]/submission-details-card/small-avatar.js
@@ -78,7 +78,7 @@ export default function SmallAvatar({ submissionId }) {
       <Link
         sx={{
           height: 32,
-          marginRight: 1,
+          marginRight: 1
         }}
         newTab
       >

--- a/components/theme-provider.js
+++ b/components/theme-provider.js
@@ -357,6 +357,15 @@ export const theme = merge(merge(base, toTheme(typographyTheme)), {
       objectFit: "contain",
       width: 32,
     },
+    challengedSmallAvatar: {
+      borderColor: "danger",
+      borderRadius: 64,
+      borderStyle: "solid",
+      borderWidth: 1,
+      height: 32,
+      objectFit: "contain",
+      width: 32,
+    },
     thumbnail: {
       borderRadius: 3,
       width: 200,


### PR DESCRIPTION
As we discussed on #483, one of the possible measures is to somehow "flag" profiles that are maliciously vouching.
On that branch I had pushed a change to show red small avatars for the vouchees that had been disputed and removed. Given that #483 is under heavy discussion, I decided to separate those two features onto two different PRs and branches. 
I believe this change should be included in master right away. 