### PR TITLE
fix(subgraph): disputed now sets to false on removeSubm.

### DIFF
--- a/subgraph/src/mapping.ts
+++ b/subgraph/src/mapping.ts
@@ -676,6 +676,7 @@ export function reapplySubmission(call: ReapplySubmissionCall): void {
 export function removeSubmission(call: RemoveSubmissionCall): void {
   let submission = Submission.load(call.inputs._submissionID.toHexString());
   managePreviousStatus(submission, call);
+  submission.disputed = false;
   submission.status = "PendingRemoval";
   submission.save();
   manageCurrentStatus(submission);


### PR DESCRIPTION
The second patch I talked about, that's probably needed. Untested, but makes sense since a request cannot be made to a submission that has one of the requests disputed.
Note `Submission` doesn't have a field `disputed` in the smart contract, which may be error prone.