### PR TITLE
fix: corrected removal request evidence file types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 /assets/seed-submissions/
 
 .env
+.vercel

--- a/_pages/profile/[id]/submission-details-card/deadlines/remove-button.js
+++ b/_pages/profile/[id]/submission-details-card/deadlines/remove-button.js
@@ -126,8 +126,8 @@ export default function RemoveButton({ request, contract, submissionID }) {
                 as={FileUpload}
                 name="file"
                 label="File"
-                accept="image/png, image/jpeg, application/pdf"
-                maxSize={2 * 1024 * 1024}
+                accept="image/png, image/jpeg, application/pdf, video/mp4, video/webm, video/quicktime"
+                maxSize={4 * 1024 * 1024}
               />
               <Button
                 sx={{ display: "block", margin: "auto" }}


### PR DESCRIPTION
removal requests from a different wallet need to have a video attached as evidence to prove ownership of the registrated address. 
UI didn't allow video files to be attached. it is corrected now. 