### PR TITLE
Fix spelling errors

### DIFF
--- a/components/button.js
+++ b/components/button.js
@@ -39,7 +39,7 @@ const Button = forwardRef(
               return `0 0 1px ${text}`;
             },
           },
-          cursor: disabled ? "not-alowed" : "pointer",
+          cursor: disabled ? "not-allowed" : "pointer",
           ...sx,
         }}
         type={type}

--- a/components/escrow-widget.stories.js
+++ b/components/escrow-widget.stories.js
@@ -39,7 +39,7 @@ const metadata = {
     metaEvidence: {
       type: { name: "object", required: true },
       description:
-        "The [meta evidence object](https://github.com/ethereum/EIPs/issues/1497) for any potential disputes arising from a transaction. You can add an additional `file` property with a buffer, string, or object, and it will be uploaded to IPFS and `fileURI` will be set appropiately.",
+        "The [meta evidence object](https://github.com/ethereum/EIPs/issues/1497) for any potential disputes arising from a transaction. You can add an additional `file` property with a buffer, string, or object, and it will be uploaded to IPFS and `fileURI` will be set appropriately.",
       table: {
         type: {
           summary: "object",

--- a/components/kleros-escrow.stories.mdx
+++ b/components/kleros-escrow.stories.mdx
@@ -104,7 +104,7 @@ Creates an escrow transaction.
 | amount\*       | `number  | string                                                                                                                                                                                                                                                           | BN`     | The amount escrowed.                                          |     |
 | recipient\*    | `string` | The address of the recipient.                                                                                                                                                                                                                                    |         |
 | timeout\*      | `number  | string                                                                                                                                                                                                                                                           | BN`     | The time in seconds until the transaction becomes executable. |     |
-| metaEvidence\* | `object` | The [meta evidence object](https://github.com/ethereum/EIPs/issues/1497) for any potential disputes arising. You can add an additional `file` property with a buffer, string, or object, and it will be uploaded to IPFS and `fileURI` will be set appropiately. |         |
+| metaEvidence\* | `object` | The [meta evidence object](https://github.com/ethereum/EIPs/issues/1497) for any potential disputes arising. You can add an additional `file` property with a buffer, string, or object, and it will be uploaded to IPFS and `fileURI` will be set appropriately. |         |
 
 #### Returns `(Promise<object>)`
 
@@ -192,7 +192,7 @@ Uploads evidence to Kleros' IPFS node and submits it for a transaction.
 | Name            | Type     | Description                                                                                                                                                                                                                                                 | Default |
 | --------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | transactionID\* | `string` | The ID of the transaction.                                                                                                                                                                                                                                  |         |
-| evidence\*      | `object` | The [evidence object](https://github.com/ethereum/EIPs/issues/1497) for any potential disputes arising. You can add an additional `file` property with a buffer, string, or object, and it will be uploaded to IPFS and `fileURI` will be set appropiately. |         |
+| evidence\*      | `object` | The [evidence object](https://github.com/ethereum/EIPs/issues/1497) for any potential disputes arising. You can add an additional `file` property with a buffer, string, or object, and it will be uploaded to IPFS and `fileURI` will be set appropriately. |         |
 
 #### Returns `(Promise<object>)`
 

--- a/subgraph/src/mapping.ts
+++ b/subgraph/src/mapping.ts
@@ -331,7 +331,7 @@ function processVouchesHelper(
 }
 
 export function vouchAddedByChangeStateToPending(event: VouchAddedEvent): void {
-  // This handler is exclusively for events VouchAdded events emited
+  // This handler is exclusively for events VouchAdded events emitted
   // by calling changeStateToPending.
   let functionSig = event.transaction.input.toHexString().slice(0, 10);
   if (functionSig === "0x32fe596f") return; // Ignore if emitted by addVouch.


### PR DESCRIPTION
1. **`button.js`**:
   - Fixed `not-alowed` to `not-allowed` in CSS cursor property.

2. **`escrow-widget.stories.js`**:
   - Corrected `appropiately` to `appropriately` in a comment regarding IPFS uploads.

3. **`kleros-escrow.stories.mdx`**:
   - Corrected `appropiately` to `appropriately` in multiple instances referring to meta evidence and evidence object descriptions.

4. **`mapping.ts`**:
   - Fixed `emited` to `emitted` in a comment describing the `VouchAdded` event handler.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected spelling of "appropriately" in various method descriptions
	- Fixed typos in documentation comments

- **Style**
	- Corrected cursor style in Button component from `not-alowed` to `not-allowed`

- **Chores**
	- Minor typographical corrections in code comments and documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->